### PR TITLE
fix(front) #6 user theme mode was sometimes false coz of useeffect

### DIFF
--- a/pixerart/src/components/NavPixer.js
+++ b/pixerart/src/components/NavPixer.js
@@ -2,7 +2,7 @@ import Navbar from 'react-bootstrap/Navbar';
 import useLocalStorage from '../lib/useLocalStorage';
 import useSessionStorage from '../lib/useSessionStorage';
 import axios from 'axios';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import {
     useNavigate
@@ -46,13 +46,18 @@ export const NavPixer = () => {
         setToken(null);
         navigate('/');
     };
+    
+    const timelineLoaded = useRef(false);
 
     useEffect(() => {
+      if (!timelineLoaded.current) {
         if (user != null) {
             if (colorMode !== user.theme)
                 toggleColorMode();
         }
-    }, [colorMode, toggleColorMode, user])
+        timelineLoaded.current = true;
+      }
+    }, [colorMode, toggleColorMode, user]);
 
     function IsLoggedIn(user) {
         let res;
@@ -93,8 +98,8 @@ export const NavPixer = () => {
                     <Flex alignItems={'center'}>
                         <IsLoggedIn user={user} />
                         <Button mx={2} onClick={() => {
-                            toggleColorMode();
                             handleChangeMode();
+                            toggleColorMode();
                         }}>
                             {colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
                         </Button>


### PR DESCRIPTION
Lorsque l'utilisateur avait en base de données un thème différent de celui affiché sur l'écran, il fallait 

Prenons un cas d'utilisation simple:  
le navigateur est en light mode, l'utilisateur Toto se connecte, il a, en base de données, un user.theme = 'dark'.
Il fallait faire en sorte, avec un useEffect, que si le user.theme était différent du thème du navigateur => voir la doc de [colormode](https://chakra-ui.com/docs/styled-system/color-mode#behavior-of-colormode) il fallait appeler toggleColorMode pour faire le changement et ainsi affecter au thème du navigateur le user.theme.  
Et ce uniquement au premier render de la page.  

Solution: useRef


@Yessine-iut, @saad-ahmed98  pour tester: 
- aller sur l'index et mettre par exemple light en cliquant dans la navbar.
- se connecter avec un user souhaitant le darkmode
- voir que ça a bien été updated
- changer le thème via la navbar
- naviguer sur une autre page
- constater que le thème est le bon (autrement dit, qu'on soit pas retourné sur le thème précédent) 

Merci,
Hugo